### PR TITLE
Ant wrapper - module ceylon.build.tasks.ant

### DIFF
--- a/.ceylon/config
+++ b/.ceylon/config
@@ -1,3 +1,6 @@
 
 [defaults]
 encoding=UTF-8
+
+[repositories]
+remote=aether

--- a/.project
+++ b/.project
@@ -13,6 +13,10 @@
 		<buildCommand>
 			<name>com.redhat.ceylon.eclipse.ui.ceylonBuilder</name>
 			<arguments>
+				<dictionary>
+					<key>systemRepo</key>
+					<value></value>
+				</dictionary>
 			</arguments>
 		</buildCommand>
 	</buildSpec>

--- a/source/ceylon/build/tasks/ant/Ant.ceylon
+++ b/source/ceylon/build/tasks/ant/Ant.ceylon
@@ -1,0 +1,107 @@
+import ceylon.build.tasks.ant.internal { AntSupport, AntProjectImplementation }
+
+"""
+   Basically it's a mapping from Ant's XML description language to Ceylon.
+   Elements and attributes are `String`s as Ant itself has a dynamic nature.
+   
+   Consider the following Ant snippet:
+   
+   ```
+   <property name="buildDirectory" value="target/build"/>
+   <copy todir="${buildDirectory}/sub-directory">
+       <fileset dir="${buildDirectory}">
+           <include name="example.txt"/>
+       </fileset>
+   </copy>
+   ```
+   
+   The above Ant snippet becomes with the value `buildDirectory` the following Ceylon code:
+   
+   ```
+   value buildDirectory = "target/build";
+   Ant("copy", { "todir" -> "``buildDirectory``/sub-directory" }, [
+       Ant("fileset", { "dir" -> "``buildDirectory``" }, [
+           Ant("include", { "name" -> "example.txt" } )
+       ] )
+   ] ).execute();
+   ```
+   
+   Take care to include the last `.execute()` directive, otherwise the operation will not get executed, or use the function `ant()` instead for Ant-tasks.
+"""
+see(`function ant`)
+shared class Ant(
+        antName,
+        {<String->String>*}? attributes = null,
+        {<Ant>*}? elements = null,
+        String? text = null) {
+    
+    """
+       Name of ant type (element name).
+    """
+    shared String antName;
+    
+    void build(AntSupport antSupport) {
+        if(exists attributes) {
+            for (attributeName -> attributeValue in attributes) {
+                antSupport.attribute(attributeName, attributeValue);
+            }
+        }
+        if(exists elements) {
+            for (element in elements) {
+                AntSupport elementAntHelper = antSupport.createNestedElement(element.antName);
+                element.build(elementAntHelper);
+                antSupport.element(elementAntHelper);
+            }
+        }
+        if(exists text) {
+            antSupport.setText(text);
+        }
+    }
+    
+    AntSupport buildAntSupport(AntProjectImplementation antProjectImplementation) {
+        AntSupport antSupport = AntSupport(antName, antProjectImplementation.projectSupport);
+        build(antSupport);
+        return antSupport;
+    }
+    
+    """
+       Executes the built up Ant directives.
+    """
+    shared void execute() {
+        AntProjectImplementation antProjectImplementation = provideAntProjectImplementation();
+        AntSupport antSupport = buildAntSupport(antProjectImplementation);
+        antSupport.execute();
+    }
+    
+    shared actual String string {
+        AntProjectImplementation antProjectImplementation = provideAntProjectImplementation();
+        AntSupport antSupport = buildAntSupport(antProjectImplementation);
+        String string = "
+                         Directory: ``antProjectImplementation.effectiveBaseDirectory()``
+                         Ant's XML: ``antSupport.string``
+                         ";
+        return string;
+    }
+    
+}
+
+"""
+   Convenience method to build `execute()` an `Ant` class when it's an Ant-task.
+   
+   ```
+   value buildDirectory = "target/build-test-file-tasks-directory";
+   ant("copy", { "todir" -> "``buildDirectory``/sub-directory" }, [
+       Ant("fileset", { "dir" -> "``buildDirectory``" }, [
+           Ant("include", { "name" -> "example.txt" } )
+       ] )
+   ] );
+   ```
+"""
+see(`class Ant`)
+shared void ant(
+        String antName,
+        {<String->String>*}? attributes = null,
+        {<Ant>*}? elements = null,
+        String? text = null) {
+    Ant(antName, attributes, elements, text).execute();
+}

--- a/source/ceylon/build/tasks/ant/AntDefinition.ceylon
+++ b/source/ceylon/build/tasks/ant/AntDefinition.ceylon
@@ -1,0 +1,92 @@
+"""
+   Ant type and task defintion returned by introspection (element defintion).
+   Ant introspection works from top down, as the implementing classes of Ant types change depending on their location in the XML hierarchy.
+   
+   Example:
+   
+   ```
+   AntProject antProject = currentAntProject();
+   AntDefinition? copyAntDefinition = antProject.topLevelAntDefinition("copy");
+   assert(exists copyAntDefinition);
+   AntDefinition? filesetAntDefinition = copyAntDefinition.nestedElementDefinition("fileset");
+   assert(exists filesetAntDefinition);
+   AntDefinition? includeAntDefinition = filesetAntDefinition.nestedElementDefinition("include");
+   assert(exists includeAntDefinition);
+   ```
+"""
+shared interface AntDefinition satisfies Comparable<AntDefinition> {
+    
+    """
+       Name of the ant type/task.
+    """
+    shared formal String antName;
+    
+    """
+       Name of implementing Java class.
+    """
+    shared formal String elementTypeClassName;
+    
+    """
+       Name of effective Java class, if `elementTypeClassName` is of type `org.apache.tools.ant.TypeAdapter` (or it's subtypes).
+    """
+    shared formal String effectiveElementTypeClassName;
+    
+    """
+       Indicates whether the effective implementation is wrapped.
+       This becomes true, when `elementTypeClassName` is of type `org.apache.tools.ant.TypeAdapter` (or it's subtypes).
+    """
+    shared formal Boolean implementationWrapped;
+    
+    """
+       List of available attributes.
+    """
+    shared formal List<AntAttributeDefinition> attributes();
+    
+    """
+       List of nested ant definitions (elements).
+    """
+    shared formal List<AntDefinition> nestedAntDefinitions();
+    
+    """
+       Indicates whether the introspected Ant defintion is a regular Ant task that can be executed.
+    """
+    shared formal Boolean isTask();
+    
+    """
+       Indicates whether the introspected Ant defintion is a data type that can appear inside the build file stand alone.
+    """
+    shared formal Boolean isDataType();
+    
+    """
+       Indicates whether the introspected Ant defintion can contain text (as Ant element).
+    """
+    shared formal Boolean isTextSupported();
+    
+    """
+       Indicates whether the introspected Ant defintion is a dynamic one, supporting arbitrary nested elements and/or attributes.
+    """
+    shared formal Boolean acceptsArbitraryNestedElementsOrAttributes();
+    
+    """
+       Indicates whether the introspected Ant defintion is a task container, supporting arbitrary nested tasks/types.
+    """
+    shared formal Boolean isContainer();
+    
+}
+
+"""
+   Ant attribute defintion returned by introspection.
+"""
+shared interface AntAttributeDefinition {
+    
+    """
+       Name of attribute.
+    """
+    shared formal String name;
+    
+    """
+       Name of corresponding Java class.
+    """
+    shared formal String className;
+    
+}

--- a/source/ceylon/build/tasks/ant/AntProject.ceylon
+++ b/source/ceylon/build/tasks/ant/AntProject.ceylon
@@ -1,0 +1,78 @@
+import ceylon.build.tasks.ant.internal { AntProjectImplementation }
+
+"""
+   Represents Ant's Project class, with the ability to access properties and Ant type definitions.
+"""
+shared interface AntProject {
+    
+    """
+       Gives all available Ant properties in this project.
+    """
+    shared formal Map<String,String> allProperties();
+    
+    """
+       Gives a specific Ant property.
+    """
+    shared formal String? getProperty(String propertyName);
+    
+    """
+       Sets an Ant property.
+    """
+    shared formal void setProperty(String propertyName, String? propertyValue);
+    
+    """
+       Sets a new base directory for the current Ant project.
+    """
+    shared formal String effectiveBaseDirectory(String? newBaseDirectory = null);
+    
+    """
+       Adds a module to the class loader, so Ant can use the classes.
+       Needed if you want to use Ant types and tasks in external modules.
+       Before actually using these types and tasks you have to initialize Ant with `typedef` or `taskdef`.
+       
+       Example:
+       ```
+       AntProject antProject = activeAntProject();
+       antProject.addModule("org.apache.ant.ant-commons-net", "1.9.4");
+       ant("taskdef", { "name" -> "ftp", "classname" -> "org.apache.tools.ant.taskdefs.optional.net.FTP" } );
+       ```
+    """
+    shared formal void addModule(String moduleName, String moduleVersion = "");
+    
+    """
+       Root of Ant type introspection.
+       Gives all top level Ant defintions.
+       Ant introspection works from top down, as the implementing classes of Ant types change depending on their location in the XML hierarchy.
+    """
+    shared formal List<AntDefinition> allTopLevelAntDefinitions();
+    
+}
+
+variable AntProjectImplementation? activeAntProjectImplementation = null;
+
+AntProjectImplementation provideAntProjectImplementation() {
+    AntProjectImplementation? antProjectImplementation = activeAntProjectImplementation;
+    if(exists antProjectImplementation) {
+        return antProjectImplementation;
+    } else {
+        AntProjectImplementation newAntProjectImplementation = AntProjectImplementation(null);
+        activeAntProjectImplementation = newAntProjectImplementation;
+        return newAntProjectImplementation;
+    }
+}
+
+"""
+   Returns the active Ant project or provides a new one if not initialized.
+"""
+shared AntProject activeAntProject() {
+    return provideAntProjectImplementation();
+}
+
+"""
+   Creates a new Ant project and sets it as the active project. With optional base directory.
+"""
+shared AntProject renewAntProject(String? baseDirectory) {
+    AntProjectImplementation newAntProjectImplementation = AntProjectImplementation(baseDirectory);
+    activeAntProjectImplementation = newAntProjectImplementation;
+    return newAntProjectImplementation;
+}

--- a/source/ceylon/build/tasks/ant/internal/AntAttributeDefinitionSupport.java
+++ b/source/ceylon/build/tasks/ant/internal/AntAttributeDefinitionSupport.java
@@ -1,0 +1,21 @@
+package ceylon.build.tasks.ant.internal;
+
+public class AntAttributeDefinitionSupport {
+    
+    private String attributeName;
+    private Class<?> attributeClass;
+    
+    public AntAttributeDefinitionSupport(String attributeName, Class<?> attributeClass) {
+        this.attributeName = attributeName;
+        this.attributeClass = attributeClass;
+    }
+    
+    public String getName() {
+        return attributeName;
+    }
+    
+    public String getClassName() {
+        return attributeClass.getName();
+    }
+    
+}

--- a/source/ceylon/build/tasks/ant/internal/AntDefinitionImplementation.ceylon
+++ b/source/ceylon/build/tasks/ant/internal/AntDefinitionImplementation.ceylon
@@ -1,0 +1,87 @@
+import ceylon.build.tasks.ant { AntDefinition, AntAttributeDefinition }
+import ceylon.collection { LinkedList }
+
+shared class AntDefinitionImplementation(AntDefinitionSupport antDefinitionSupport) satisfies AntDefinition {
+    
+    shared actual String antName = antDefinitionSupport.antName;
+    shared actual String elementTypeClassName = antDefinitionSupport.elementType.name;
+    shared actual String effectiveElementTypeClassName = antDefinitionSupport.effectiveElementType.name;
+    shared actual Boolean implementationWrapped = antDefinitionSupport.elementType.name != antDefinitionSupport.effectiveElementType.name;
+    
+    shared actual List<AntAttributeDefinition> attributes() {
+        LinkedList<AntAttributeDefinitionSupport> antAttributeDefinitionSupportList = LinkedList<AntAttributeDefinitionSupport>();
+        antDefinitionSupport.fillAttributeList(antAttributeDefinitionSupportList);
+        {AntAttributeDefinition*} antAttributeDefinitions = antAttributeDefinitionSupportList.map<AntAttributeDefinition>(
+            (AntAttributeDefinitionSupport a) => AntAttributeDefinitionImplementation(a.name, a.className)
+        );
+        AntAttributeDefinition[] result = antAttributeDefinitions.sort(byIncreasing((AntAttributeDefinition a) => a.name));
+        return result;
+    }
+    
+    shared actual List<AntDefinition> nestedAntDefinitions() {
+        LinkedList<AntDefinitionSupport> nestedAntDefinitionSupportList = LinkedList<AntDefinitionSupport>();
+        antDefinitionSupport.fillNestedAntDefinitionList(nestedAntDefinitionSupportList);
+        LinkedList<AntDefinition> nestedAntDefinitionList = LinkedList<AntDefinition>();
+        for (nestedAntDefinitionSupport in nestedAntDefinitionSupportList) {
+            AntDefinition nestedAntDefinition = AntDefinitionImplementation(nestedAntDefinitionSupport);
+            nestedAntDefinitionList.add(nestedAntDefinition);
+        }
+        AntDefinition[] result = nestedAntDefinitionList.sort(byIncreasing((AntDefinition a) => a));
+        return result;
+    }
+    
+    shared actual Boolean isTask() {
+        return antDefinitionSupport.task;
+    }
+    
+    shared actual Boolean isDataType() {
+        return antDefinitionSupport.dataType;
+    }
+    
+    shared actual Boolean isTextSupported() {
+        return antDefinitionSupport.textSupported;
+    }
+    
+    shared actual Boolean acceptsArbitraryNestedElementsOrAttributes() {
+        return antDefinitionSupport.acceptsArbitraryNestedElementsOrAttributes();
+    }
+    
+    shared actual Boolean isContainer() {
+        return antDefinitionSupport.container;
+    }
+    
+    shared actual Boolean equals(Object otherObject) {
+        if(is AntDefinition otherObject) {
+            return ((isTask() == otherObject.isTask()) && antName == otherObject.antName) && (elementTypeClassName == otherObject.elementTypeClassName);
+        }
+        return false;
+    }
+    
+    shared actual Integer hash {
+        return antName.hash + elementTypeClassName.hash;
+    }
+    
+    shared actual Comparison compare(AntDefinition other) {
+        if(isTask() && !other.isTask()) {
+            return larger;
+        }
+        if(!isTask() && other.isTask()) {
+            return smaller;
+        }
+        Comparison nameComparision = antName <=> other.antName;
+        if(nameComparision != equal) {
+            return nameComparision;
+        }
+        return elementTypeClassName <=> other.elementTypeClassName;
+    }
+    
+    shared actual String string {
+        return "``isTask() then "AntTask" else "AntType"``: ``antName``#``elementTypeClassName``";
+    }
+    
+}
+
+shared class AntAttributeDefinitionImplementation(name, className) satisfies AntAttributeDefinition {
+    shared actual String name;
+    shared actual String className;
+}

--- a/source/ceylon/build/tasks/ant/internal/AntDefinitionSupport.java
+++ b/source/ceylon/build/tasks/ant/internal/AntDefinitionSupport.java
@@ -1,0 +1,95 @@
+package ceylon.build.tasks.ant.internal;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.tools.ant.IntrospectionHelper;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+import org.apache.tools.ant.types.DataType;
+
+import ceylon.collection.LinkedList;
+
+public class AntDefinitionSupport {
+    
+    private Project project;
+    private String antName;
+    private Class<Object> elementType;
+    private Class<Object> effectiveElementType;
+    private IntrospectionHelper introspectionHelper;
+    private boolean definitelyType;
+    
+    public AntDefinitionSupport(Project project, String antName, Class<Object> elementType, Class<Object> effectiveElementType, IntrospectionHelper introspectionHelper, boolean definitelyType) {
+        this.project = project;
+        this.antName = antName;
+        this.elementType = elementType;
+        this.effectiveElementType = effectiveElementType;
+        this.introspectionHelper = introspectionHelper;
+        this.definitelyType = definitelyType;
+    }
+    
+    public void fillAttributeList(LinkedList<AntAttributeDefinitionSupport> result) {
+        Map<String, Class<?>> attributeMap = introspectionHelper.getAttributeMap();
+        for(Entry<String, Class<?>> attribute : attributeMap.entrySet()) {
+            String attributeName = attribute.getKey();
+            Class<?> attributeClass = attribute.getValue();
+            AntAttributeDefinitionSupport antAttributeDefinition = new AntAttributeDefinitionSupport(attributeName, attributeClass);
+            result.add(antAttributeDefinition);
+        }
+    }
+    
+    public void fillNestedAntDefinitionList(LinkedList<AntDefinitionSupport> result) {
+        Map<String, Class<?>> nestedElementMap = introspectionHelper.getNestedElementMap();
+        for(Entry<String, Class<?>> nestedElementEntry : nestedElementMap.entrySet()) {
+            String nestedElementName = nestedElementEntry.getKey().toLowerCase(Locale.ENGLISH);
+            @SuppressWarnings("unchecked")
+            Class<Object> nestedElementType = (Class<Object>) nestedElementEntry.getValue();
+            IntrospectionHelper nestedIntrospectionHelper = IntrospectionHelper.getHelper(project, nestedElementType);
+            AntDefinitionSupport antDefinitionSupport = new AntDefinitionSupport(project, nestedElementName, nestedElementType, nestedElementType, nestedIntrospectionHelper, true);
+            result.add(antDefinitionSupport);
+        }
+    }
+    
+    public String getAntName() {
+        return antName;
+    }
+    
+    public Project getProject() {
+        return project;
+    }
+    
+    public IntrospectionHelper getIntrospectionHelper() {
+        return introspectionHelper;
+    }
+    
+    public Class<Object> getElementType() {
+        return elementType;
+    }
+    
+    public Class<Object> getEffectiveElementType() {
+        return effectiveElementType;
+    }
+    
+    public boolean isTask() {
+        return !definitelyType && Task.class.isAssignableFrom(elementType);
+    }
+    
+    public boolean isDataType() {
+        return DataType.class.isAssignableFrom(elementType);
+    }
+    
+    public boolean isTextSupported() {
+        return introspectionHelper.supportsCharacters();
+    }
+    
+    // needs to be implemented explicitly, because "dynamic" is a Ceylon keyword
+    public boolean acceptsArbitraryNestedElementsOrAttributes() {
+        return introspectionHelper.isDynamic();
+    }
+    
+    public boolean isContainer() {
+        return introspectionHelper.isContainer();
+    }
+    
+}

--- a/source/ceylon/build/tasks/ant/internal/AntProjectImplementation.ceylon
+++ b/source/ceylon/build/tasks/ant/internal/AntProjectImplementation.ceylon
@@ -1,0 +1,46 @@
+import ceylon.collection { HashMap, LinkedList }
+
+import ceylon.build.tasks.ant { AntDefinition, AntProject }
+
+shared class AntProjectImplementation(String? baseDirectory) satisfies AntProject {
+    
+    shared ProjectSupport projectSupport = ProjectSupport(baseDirectory);
+    
+    shared actual Map<String,String> allProperties() {
+        HashMap<String,String> result = HashMap<String,String>();
+        projectSupport.fillAllPropertiesMap(result);
+        return result;
+    }
+    
+    shared actual String? getProperty(String propertyName) {
+        return projectSupport.getProperty(propertyName);
+    }
+    
+    shared actual void setProperty(String propertyName, String? propertyValue) {
+        projectSupport.setProperty(propertyName, propertyValue);
+    }
+    
+    shared actual String effectiveBaseDirectory(String? newBaseDirectory) {
+        if(exists newBaseDirectory) {
+            projectSupport.baseDirectory = newBaseDirectory;
+        }
+        return projectSupport.baseDirectory;
+    }
+    
+    shared actual void addModule(String moduleName, String moduleVersion) {
+        projectSupport.addModule(moduleName, moduleVersion);
+    }
+    
+    shared actual List<AntDefinition> allTopLevelAntDefinitions() {
+        LinkedList<AntDefinitionSupport> topLevelAntDefinitionSupportList = LinkedList<AntDefinitionSupport>();
+        projectSupport.fillTopLevelAntDefinitionSupportList(topLevelAntDefinitionSupportList);
+        LinkedList<AntDefinition> allTopLevelAntDefinitions = LinkedList<AntDefinition>();
+        for (topLevelAntDefinitionSupport in topLevelAntDefinitionSupportList) {
+            AntDefinition topLevelAntDefinition = AntDefinitionImplementation(topLevelAntDefinitionSupport);
+            allTopLevelAntDefinitions.add(topLevelAntDefinition);
+        }
+        AntDefinition[] sortedTopLevelAntDefinitions = allTopLevelAntDefinitions.sort(byIncreasing((AntDefinition a) => a));
+        return sortedTopLevelAntDefinitions;
+    }
+    
+}

--- a/source/ceylon/build/tasks/ant/internal/AntSupport.java
+++ b/source/ceylon/build/tasks/ant/internal/AntSupport.java
@@ -1,0 +1,174 @@
+package ceylon.build.tasks.ant.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.tools.ant.AntTypeDefinition;
+import org.apache.tools.ant.ComponentHelper;
+import org.apache.tools.ant.IntrospectionHelper;
+import org.apache.tools.ant.IntrospectionHelper.Creator;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.Task;
+import org.apache.tools.ant.TypeAdapter;
+import org.apache.tools.ant.taskdefs.AntlibDefinition;
+import org.apache.tools.ant.types.DataType;
+
+public class AntSupport {
+    
+    protected String antName;
+    private ProjectSupport projectSupport;
+    private Object instantiateObject;
+    private Object effectiveObject;
+    private IntrospectionHelper introspectionHelper;
+    private List<AntSupport> appliedElements = new ArrayList<AntSupport>();
+    private Map<String, Object> appliedAttributeMap = new HashMap<String, Object>();
+    private String appliedText;
+    
+    public AntSupport() {
+    }
+    
+    public AntSupport(String antName, ProjectSupport projectSupport) {
+        this.antName= antName;
+        this.projectSupport = projectSupport;
+        Project project = getProject();
+        ComponentHelper componentHelper = ComponentHelper.getComponentHelper(project);
+        AntTypeDefinition antTypeDefinition = componentHelper.getDefinition(antName);
+        if (antTypeDefinition == null) {
+            throw new AntSupportException("Ant type <" + antName + "> is unknown.");
+        }
+        instantiateObject = antTypeDefinition.create(project);
+        if (instantiateObject == null) {
+            throw new AntSupportException("Ant type <" + antName + "> has no known class instance.");
+        }
+        if (instantiateObject instanceof TypeAdapter) {
+            TypeAdapter typeAdapter = ((TypeAdapter) instantiateObject);
+            typeAdapter.setProject(project);
+            effectiveObject = typeAdapter.getProxy();
+        } else {
+            effectiveObject = instantiateObject;
+        }
+        if (effectiveObject instanceof AntlibDefinition) {
+            AntlibDefinition antlibDefinition = (AntlibDefinition) effectiveObject;
+            antlibDefinition.setAntlibClassLoader(this.projectSupport.getClassLoader());
+        }
+        introspectionHelper = IntrospectionHelper.getHelper(project, effectiveObject.getClass());
+    }
+    
+    private Project getProject() {
+        return projectSupport.getProject();
+    }
+
+    private AntSupport(String nestedElementName, ProjectSupport projectSupport, Object instantiatedObject) {
+        this.antName= nestedElementName;
+        this.projectSupport = projectSupport;
+        this.instantiateObject = instantiatedObject;
+        effectiveObject = instantiatedObject;
+        if (instantiatedObject instanceof TypeAdapter) {
+            effectiveObject = ((TypeAdapter) instantiatedObject).getProxy();
+        }
+        introspectionHelper = IntrospectionHelper.getHelper(getProject(), effectiveObject.getClass());
+    }
+    
+    public void attribute(String name, Object value) {
+        introspectionHelper.setAttribute(getProject(), effectiveObject, name, value);
+        appliedAttributeMap.put(name, value);
+    }
+    
+    public void element(AntSupport element) {
+        introspectionHelper.storeElement(getProject(), effectiveObject, element.effectiveObject, element.antName);
+        appliedElements.add(element);
+    }
+    
+    public void setText(String text) {
+        introspectionHelper.addText(getProject(), effectiveObject, text);
+        appliedText = text;
+    }
+    
+    public Map<String, Class<?>> getAttributeMap() {
+        Map<String, Class<?>> attributeMap = introspectionHelper.getAttributeMap();
+        return attributeMap;
+    }
+    
+    public Map<String, Class<?>> getElementMap () {
+        Map<String, Class<?>> nestedElementMap = introspectionHelper.getNestedElementMap();
+        return nestedElementMap;
+    }
+    
+    public AntSupport createNestedElement(String nestedElementName) {
+        Creator creator = introspectionHelper.getElementCreator(getProject(), "", effectiveObject, nestedElementName, null);
+        Object object = creator.create();
+        AntSupport antSupport = new AntSupport(nestedElementName, projectSupport, object);
+        return antSupport;
+    }
+    
+    public String getAntName() {
+        return antName;
+    }
+    
+    public boolean isTask() {
+        return instantiateObject instanceof Task;
+    }
+    
+    public boolean isDataType() {
+        return instantiateObject instanceof DataType;
+    }
+    
+    public boolean isTextSupported() {
+        return introspectionHelper.supportsCharacters();
+    }
+    
+    // needs to be implemented explicitly, because "dynamic" is a Ceylon keyword
+    public boolean isDynamicType() {
+        return introspectionHelper.isDynamic();
+    }
+    
+    public boolean isContainer() {
+        return introspectionHelper.isContainer();
+    }
+    
+    public Object getInstantiatedObject() {
+        return instantiateObject;
+    }
+    
+    public Object getEffectiveObject() {
+        return effectiveObject;
+    }
+    
+    public void execute() {
+        if(isTask()) {
+            Task task = (Task) instantiateObject;
+            task.execute();
+        } else {
+            throw new AntSupportException("Ant type " + antName + " is not an executable task.");
+        }
+    }
+    
+    public String toString() {
+        String result = "<" + antName;
+        List<String> attributeNames = new ArrayList<String>(appliedAttributeMap.keySet());
+        Collections.sort(attributeNames);
+        for(String attributeName : attributeNames) {
+            Object attributeValue = appliedAttributeMap.get(attributeName);
+            result += " " + attributeName + "=\"" + attributeValue + "\"";
+        }
+        if(appliedText != null || appliedElements.size() > 0) {
+            result += ">";
+        }
+        for(AntSupport subElement : appliedElements) {
+            result += subElement.toString();
+        }
+        if(appliedText != null) {
+            result += appliedText + "</" + antName + ">";
+        } else if (appliedElements.size() > 0) {
+            result += "</" + antName + ">";
+        } else {
+            result += "/>";
+        }
+        return result;
+    }
+    
+}
+

--- a/source/ceylon/build/tasks/ant/internal/AntSupportException.java
+++ b/source/ceylon/build/tasks/ant/internal/AntSupportException.java
@@ -1,0 +1,15 @@
+package ceylon.build.tasks.ant.internal;
+
+public class AntSupportException extends RuntimeException {
+    
+    private static final long serialVersionUID = 1L;
+    
+    public AntSupportException(String message) {
+        super(message);
+    }
+    
+    public AntSupportException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+}

--- a/source/ceylon/build/tasks/ant/internal/MultiModuleClassLoader.java
+++ b/source/ceylon/build/tasks/ant/internal/MultiModuleClassLoader.java
@@ -1,0 +1,133 @@
+package ceylon.build.tasks.ant.internal;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Vector;
+
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleClassLoader;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoadException;
+
+class MultiModuleClassLoader extends ClassLoader {
+    
+    private static class ClassLoaderTuple {
+        String name;
+        ClassLoader classLoader;
+        ClassLoaderTuple(String name, ClassLoader classLoader) {
+            this.name = name;
+            this.classLoader = classLoader;
+        }
+        public String toString() {
+            return name;
+        }
+    }
+    
+    private ClassLoaderTuple parentClassLoaderTuple;
+    private Vector<ClassLoaderTuple> classLoaderTuples = new Vector<>();
+    
+    public MultiModuleClassLoader(ClassLoader parentClassloader) {
+        super(null);
+        parentClassLoaderTuple = new ClassLoaderTuple("*parent*", parentClassloader);
+        classLoaderTuples.add(parentClassLoaderTuple);
+    }
+    
+    public void addModule(String moduleName, String moduleVersion) throws ModuleLoadException, ClassNotFoundException {
+        ModuleIdentifier moduleIdentifier = ModuleIdentifier.create(moduleName, moduleVersion);
+        Module jBossModule = Module.getCallerModuleLoader().loadModule(moduleIdentifier);
+        ModuleClassLoader moduleClassLoader = jBossModule.getClassLoader();
+        String name = moduleName + "/" + moduleVersion;
+        ClassLoaderTuple classLoaderTuple = new ClassLoaderTuple(name, moduleClassLoader);
+        classLoaderTuples.add(classLoaderTuple);
+    }
+    
+    @Override
+    public URL getResource(String resourceName) {
+        log("MultiModuleClassLoader getResource(): " + resourceName);
+        URL result = null;
+        for (ClassLoaderTuple classLoaderTuple : classLoaderTuples) {
+            ClassLoader classLoader = classLoaderTuple.classLoader; 
+            result = classLoader.getResource(resourceName);
+            if (result != null) {
+                break;
+            }
+        }
+        return result;
+    }
+    
+    @Override
+    public Enumeration<URL> getResources(String resourceName) throws IOException {
+        log("MultiModuleClassLoader getResources(): " + resourceName);
+        Vector<URL> result = new Vector<URL>(); 
+        for (ClassLoaderTuple classLoaderTuple : classLoaderTuples) {
+            ClassLoader classLoader = classLoaderTuple.classLoader; 
+            try {
+                Enumeration<URL> resources = classLoader.getResources(resourceName);
+                ArrayList<URL> list = Collections.list(resources);
+                result.addAll(list);
+            } catch (IOException ioException) {
+                // continue
+            }
+        }
+        return result.elements();
+    }
+    
+    @Override
+    public InputStream getResourceAsStream(String resourceName) {
+        log("MultiModuleClassLoader getResourceAsStream(): " + resourceName);
+        InputStream result = null;
+        for (ClassLoaderTuple classLoaderTuple : classLoaderTuples) {
+            ClassLoader classLoader = classLoaderTuple.classLoader; 
+            result = classLoader.getResourceAsStream(resourceName);
+            if (result != null) {
+                break;
+            }
+        }
+        return result;
+    }
+    
+    @Override
+    public Class<?> loadClass(String className) throws ClassNotFoundException {
+        log("MultiModuleClassLoader loadClass(): " + className);
+        try {
+            ClassLoader classLoader = parentClassLoaderTuple.classLoader;
+            Class<?> loadClass = classLoader.loadClass(className);
+            log("Found in parent classloader.");
+            return loadClass;
+        } catch (ClassNotFoundException classNotFoundException) {
+            // continue
+        }
+        String resourceName = className.replace('.', '/') + ".class";
+        for (ClassLoaderTuple classLoaderTuple : classLoaderTuples) {
+            ClassLoader classLoader = classLoaderTuple.classLoader; 
+            InputStream inputStream = classLoader.getResourceAsStream(resourceName);
+            if (inputStream != null) {
+                try {
+                    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                    int byteRead;
+                    while ((byteRead = inputStream.read()) != -1) {
+                      buffer.write(byteRead);
+                    }
+                    buffer.flush();
+                    byte[] bytes = buffer.toByteArray();
+                    Class<?> result = super.defineClass(className, bytes, 0, bytes.length);
+                    super.resolveClass(result);
+                    log("Found in module " + classLoaderTuple.name);
+                    return result;
+                } catch (IOException e) {
+                    // continue with next class loader
+                }
+            }
+        }
+        throw new ClassNotFoundException("Could not load class " + className + " from modules " + classLoaderTuples);
+    }
+    
+    private void log(String string) {
+        // System.out.println(string);
+    }
+    
+}

--- a/source/ceylon/build/tasks/ant/internal/ProjectCreator.java
+++ b/source/ceylon/build/tasks/ant/internal/ProjectCreator.java
@@ -1,0 +1,88 @@
+package ceylon.build.tasks.ant.internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.util.Vector;
+
+import org.apache.tools.ant.BuildLogger;
+import org.apache.tools.ant.DefaultLogger;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.ProjectHelper;
+import org.apache.tools.ant.ProjectHelperRepository;
+import org.apache.tools.ant.types.resources.StringResource;
+
+public class ProjectCreator {
+    
+    private static class BytesURLStreamHandler extends URLStreamHandler {
+        public URLConnection openConnection(URL url) {
+            return new BytesURLConnection(url);
+        }
+    }
+    
+    private static class BytesURLConnection extends URLConnection {
+        protected byte[] content;
+        public BytesURLConnection(URL url) {
+            super(url);
+            String string = url.toString().substring("bytes:".length());
+            this.content = string.getBytes();
+        }
+        public void connect() {
+        }
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(content);
+        }
+    }
+    
+    static class ProjectTuple {
+        Project project;
+        MultiModuleClassLoader multiModuleClassLoader;
+        public ProjectTuple(Project project, MultiModuleClassLoader multiModuleClassLoader) {
+            this.project = project;
+            this.multiModuleClassLoader = multiModuleClassLoader;
+        }
+    }
+    
+    private final static String MINIMAL_BUILD_FILE = "<project default=\"main\" basedir=\".\"><target name=\"main\"><echo message=\"Hello world!\"/></target></project>";
+    
+    static ProjectTuple createProject() {
+        try {
+            Project project = new Project();
+            // set ClassLoader
+            ClassLoader projectClassLoader = project.getClass().getClassLoader();
+            MultiModuleClassLoader multiModuleClassLoader = new MultiModuleClassLoader(projectClassLoader);
+            project.setCoreLoader(multiModuleClassLoader);
+            // first simulate project
+            project.fireBuildStarted();
+            // do what ProjectHelper.configureProject(project, new File("build.xml")); does with the minimal build file
+            StringResource stringResource = new StringResource(project, MINIMAL_BUILD_FILE);
+            URL url = new URL(null, "bytes:" + MINIMAL_BUILD_FILE, new BytesURLStreamHandler());
+            ProjectHelper projectHelper = ProjectHelperRepository.getInstance().getProjectHelperForBuildFile(stringResource);
+            project.addReference(ProjectHelper.PROJECTHELPER_REFERENCE, projectHelper);
+            projectHelper.parse(project, url);
+            // execute main with echo task, so that tasks get known to Ant
+            Vector<String> targets = new Vector<>();
+            targets.add("main");
+            project.executeTargets(targets);
+            // set logger
+            project.addBuildListener(createLogger());
+            // return ProjectTuple
+            ProjectTuple projectTuple = new ProjectTuple(project, multiModuleClassLoader);
+            return projectTuple;
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Cannot handle internal URL.", e);
+        }
+    }
+    
+    private static BuildLogger createLogger() {
+        BuildLogger logger = new DefaultLogger();
+        logger.setMessageOutputLevel(Project.MSG_INFO);
+        logger.setOutputPrintStream(System.out);
+        logger.setErrorPrintStream(System.err);
+        return logger;
+    }
+    
+}

--- a/source/ceylon/build/tasks/ant/internal/ProjectSupport.java
+++ b/source/ceylon/build/tasks/ant/internal/ProjectSupport.java
@@ -1,0 +1,109 @@
+package ceylon.build.tasks.ant.internal;
+
+import java.io.File;
+import java.util.Hashtable;
+import java.util.Locale;
+import java.util.Map.Entry;
+
+import org.apache.tools.ant.AntTypeDefinition;
+import org.apache.tools.ant.ComponentHelper;
+import org.apache.tools.ant.IntrospectionHelper;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.TypeAdapter;
+import org.jboss.modules.ModuleLoadException;
+
+import ceylon.build.tasks.ant.internal.ProjectCreator.ProjectTuple;
+import ceylon.collection.HashMap;
+import ceylon.collection.LinkedList;
+
+public class ProjectSupport {
+    
+    private Project project;
+    private MultiModuleClassLoader multiModuleClassLoader;
+    
+    public ProjectSupport(String baseDirectory) {
+        ProjectTuple projectTuple = ProjectCreator.createProject();
+        project = projectTuple.project;
+        multiModuleClassLoader = projectTuple.multiModuleClassLoader;
+        if(baseDirectory != null) {
+            project.setBaseDir(new File(baseDirectory));
+        }
+    }
+    
+    public Project getProject() {
+        return project;
+    }
+    
+    public void fillAllPropertiesMap(HashMap<ceylon.language.String, ceylon.language.String> result) {
+        Hashtable<String, Object> properties = project.getProperties();
+        for(String propertyName : properties.keySet()) {
+            Object propertyObject = properties.get(propertyName);
+            if(propertyObject != null) {
+                String propertyValue = propertyObject.toString();
+                ceylon.language.String propertyNameCeylonString = new ceylon.language.String(propertyName);
+                ceylon.language.String propertyValueCeylonString = new ceylon.language.String(propertyValue);
+                result.put(propertyNameCeylonString, propertyValueCeylonString);
+            }
+        }
+    }
+    
+    public String getProperty(String propertyName) {
+        return project.getProperty(propertyName);
+    }
+    
+    public void setProperty(String propertyName, String propertyValue) {
+        project.setProperty(propertyName, propertyValue);
+    }
+    
+    public String getBaseDirectory() {
+        return project.getBaseDir().toString();
+    }
+    
+    public void setBaseDirectory(String newBaseDirectory) {
+        project.setBaseDir(new File(newBaseDirectory));
+    }
+    
+    public void addModule(String moduleName, String moduleVersion) throws ModuleLoadException, ClassNotFoundException {
+        multiModuleClassLoader.addModule(moduleName, moduleVersion);
+    }
+    
+    public ClassLoader getClassLoader() {
+        return multiModuleClassLoader;
+    }
+    
+    public void fillTopLevelAntDefinitionSupportList(LinkedList<AntDefinitionSupport> result) {
+        ComponentHelper componentHelper = ComponentHelper.getComponentHelper(project);
+        Hashtable<String, AntTypeDefinition> antTypeTable = componentHelper.getAntTypeTable();
+        for(Entry<String, AntTypeDefinition> antTypeEntry : antTypeTable.entrySet()) {
+            try {
+                String antName = antTypeEntry.getKey().toLowerCase(Locale.ENGLISH);
+                AntTypeDefinition antTypeDefinition = componentHelper.getDefinition(antName);
+                Object instantiateObject = antTypeDefinition.create(project);
+                Object effectiveObject = instantiateObject;
+                if (instantiateObject instanceof TypeAdapter) {
+                    effectiveObject = ((TypeAdapter) instantiateObject).getProxy();
+                }
+                @SuppressWarnings("unchecked")
+                Class<Object> instantiatedType = (Class<Object>) instantiateObject.getClass();
+                @SuppressWarnings("unchecked")
+                Class<Object> effectiveType = (Class<Object>) effectiveObject.getClass();
+                IntrospectionHelper introspectionHelper = IntrospectionHelper.getHelper(project, effectiveType);
+                AntDefinitionSupport antDefinitionSupport = new AntDefinitionSupport(project, antName, instantiatedType, effectiveType, introspectionHelper, false);
+                result.add(antDefinitionSupport);
+            } catch (Exception exception) {
+                // continue with next Ant type, most likely couldn't instantiate object
+            }
+        }
+    }
+    
+    public IntrospectionHelper introspectionHelper(String antName, Class<Object> instantiatedClass) {
+        try {
+            Project project = getProject();
+            IntrospectionHelper introspectionHelper = IntrospectionHelper.getHelper(project, instantiatedClass);
+            return introspectionHelper;
+        } catch (Throwable throwable) {
+            return null;
+        }
+    }
+    
+}

--- a/source/ceylon/build/tasks/ant/internal/package.ceylon
+++ b/source/ceylon/build/tasks/ant/internal/package.ceylon
@@ -1,0 +1,1 @@
+package ceylon.build.tasks.ant.internal;

--- a/source/ceylon/build/tasks/ant/module.ceylon
+++ b/source/ceylon/build/tasks/ant/module.ceylon
@@ -1,0 +1,92 @@
+"""
+   # Apache Ant wrapper
+   
+   Enables you to write Apache Ant scripts in Ceylon.
+   [Apache Ant](https://ant.apache.org/) is a build/batch tool widely used by Java programmers, with which XML is commonly used as definition language.
+   
+   It facilitates the use of Ant-types, Ant-tasks, and Ant-processes, including introspection, being used within Ceylon.
+   It is not intended to imitate Ant's `target` mechanism.
+   
+   
+   
+   ## Usage
+   
+   Basically it's a mapping from Ant's XML description language to Ceylon.
+   Elements and attributes are `String`s as Ant itself has a dynamic nature.
+   
+   Also it is important to distinguish between Ant types and Ant tasks.
+   Types are data holders like `<fileset>` and task are executables like `<copy>`.
+   
+   Consider the following Ant snippet:
+   
+   ```
+   <property name="buildDirectory" value="target/build"/>
+   <copy todir="${buildDirectory}/sub-directory">
+       <fileset dir="${buildDirectory}">
+           <include name="example.txt"/>
+       </fileset>
+   </copy>
+   ```
+   
+   The above Ant snippet becomes with the value `buildDirectory` the following Ceylon code:
+   
+   ```
+   value buildDirectory = "target/build";
+   ant("copy", { "todir" -> "``buildDirectory``/sub-directory" }, [
+       Ant("fileset", { "dir" -> "``buildDirectory``" }, [
+           Ant("include", { "name" -> "example.txt" } )
+       ] )
+   ] );
+   ```
+   
+   So types like `<fileset>` are built using the `Ant` class.
+   For executing a tasks, use the `ant()` functions, which actually builds an `Ant` object and then calls `execute()` on it.
+   
+   
+   
+   ## External modules
+   
+   Ant allows users to add their own types and tasks by adding them to Java's classpath.
+   As the module system doesn't allow using classes from modules not imported directly, you need to use `AntProject::addModule()` to add a module to the class loader of `ceylon.build.tasks.ant`, so Ant can use the classes.
+   Before actually using these types and tasks you have to initialize Ant with `<typedef>` or `<taskdef>`.
+   
+   Example:
+   
+   ```
+   AntProject antProject = activeAntProject();
+   antProject.addModule("org.apache.ant.ant-commons-net", "1.9.4");
+   ant("taskdef", { "name" -> "ftp", "classname" -> "org.apache.tools.ant.taskdefs.optional.net.FTP" } );
+   ```
+   
+   
+   
+   ## Introspection
+   
+   Ant introspection works from top down, as the implementing classes of Ant types change depending on their location in the XML hierarchy.
+   
+   Example:
+   
+   ```
+   AntProject antProject = currentAntProject();
+   AntDefinition? copyAntDefinition = antProject.allTopLevelAntDefinitions().filter { (AntDefinition a) => (a.antName == "copy"); }.first;
+   assert(exists copyAntDefinition);
+   AntDefinition? filesetAntDefinition = copyAntDefinition.nestedAntDefinitions().filter { (AntDefinition a) => (a.antName == "fileset"); }.first;
+   assert(exists filesetAntDefinition);
+   AntDefinition? includeAntDefinition = includeAntDefinition.nestedAntDefinitions().filter { (AntDefinition a) => (a.antName == "include"); }.first;
+   assert(exists includeAntDefinition);
+   ```
+   
+   
+   
+   ## Caveats
+   
+   XML/Ant namespaces are not supported.
+"""
+by ("Henning Burdack")
+license ("[ASL 2.0](http://www.apache.org/licenses/LICENSE-2.0)")
+module ceylon.build.tasks.ant "1.1.0"{
+    shared import ceylon.collection "1.1.0";
+    import java.base "7";
+    import org.apache.ant.ant "1.9.4";
+    import org.jboss.modules "1.3.3.Final"; // needed for manual modules loading
+}

--- a/source/ceylon/build/tasks/ant/package.ceylon
+++ b/source/ceylon/build/tasks/ant/package.ceylon
@@ -1,0 +1,1 @@
+shared package ceylon.build.tasks.ant;

--- a/test-source/test/ceylon/build/tasks/ant/init.ceylon
+++ b/test-source/test/ceylon/build/tasks/ant/init.ceylon
@@ -1,0 +1,26 @@
+import ceylon.test { beforeTest, afterTest }
+import ceylon.build.tasks.file { delete, createDirectory }
+import ceylon.file { parsePath, Path, Nil }
+import ceylon.build.task { Writer, setContextForTask, clearTaskContext }
+import ceylon.build.tasks.ant { renewAntProject }
+
+Path baseWorkingPath = parsePath("tmp/test/ceylon/build/tasks/ant");
+
+beforeTest void cleanTestDirectory() {
+    object writer satisfies Writer {
+        shared actual void error(String message) {}
+        shared actual void info(String message) {}
+    }
+    setContextForTask([], writer);
+    delete(baseWorkingPath);
+    value baseWorkingResource = baseWorkingPath.resource;
+    "Test directory already exists"
+    assert(is Nil baseWorkingResource);
+    createDirectory(baseWorkingResource);
+    // set base directory for Ant
+    renewAntProject(baseWorkingPath.string);
+}
+
+afterTest void resetContext() {
+    clearTaskContext();
+}

--- a/test-source/test/ceylon/build/tasks/ant/module.ceylon
+++ b/test-source/test/ceylon/build/tasks/ant/module.ceylon
@@ -1,0 +1,13 @@
+"""
+   Tests the module `ceylon.build.tasks.ant`.
+"""
+by ("Henning Burdack")
+license ("[ASL 2.0](http://www.apache.org/licenses/LICENSE-2.0)")
+module test.ceylon.build.tasks.ant "1.1.0" {
+    import ceylon.build.tasks.ant "1.1.0";
+    import ceylon.build.tasks.file "1.1.0";
+    import ceylon.file "1.1.0";
+    import ceylon.test "1.1.0";
+    import "org.apache.ant.ant-commons-net" "1.9.4";
+    import "org.apache.ivy.ivy" "2.3.0";
+}

--- a/test-source/test/ceylon/build/tasks/ant/package.ceylon
+++ b/test-source/test/ceylon/build/tasks/ant/package.ceylon
@@ -1,0 +1,1 @@
+shared package test.ceylon.build.tasks.ant;

--- a/test-source/test/ceylon/build/tasks/ant/testAnt.ceylon
+++ b/test-source/test/ceylon/build/tasks/ant/testAnt.ceylon
@@ -1,0 +1,141 @@
+import ceylon.build.tasks.ant { ant, activeAntProject, Ant, AntProject, AntDefinition, AntAttributeDefinition }
+import ceylon.test { assertEquals, assertTrue, assertFalse, test }
+import ceylon.file { File, Directory, Nil }
+
+test void testEcho() {
+    ant("echo", { "message" -> "G'day mate! " }, {}, "Cheerio!" );
+}
+
+test void testFileTasks() {
+    String buildDirectory = "target/build-test-file-tasks-directory";
+    Ant fileset = Ant("fileset", { "dir" -> "``buildDirectory``" }, [
+        Ant("include", { "name" -> "example.txt" } )
+    ] );
+    ant("mkdir", { "dir" -> "``buildDirectory``" } );
+    verifyResource("``buildDirectory``", `Directory`, "Cannot create directory");
+    ant("echo", { "message" -> "File created.", "file" -> "``buildDirectory``/example.txt" } );
+    verifyResource("``buildDirectory``/example.txt", `File`, "Cannot create file");
+    ant("mkdir", { "dir" -> "``buildDirectory``/sub-directory" } );
+    verifyResource("``buildDirectory``/sub-directory", `Directory`, "Cannot create directory");
+    ant("copy", { "todir" -> "``buildDirectory``/sub-directory" }, [
+        fileset
+    ] );
+    verifyResource("``buildDirectory``/sub-directory/example.txt", `File`, "Cannot copy to file");
+    ant("delete", { }, [
+        fileset
+    ] );
+    verifyResource("``buildDirectory``/example.txt", `Nil`, "Cannot delete file");
+    ant("delete", { "dir" -> "``buildDirectory``", "verbose" -> "true" } );
+    verifyResource("``buildDirectory``", `Nil`, "Cannot delete directory");
+}
+
+test void testAntDefinitions() {
+    AntProject antProject = activeAntProject();
+    List<AntDefinition> allTopLevelAntDefinitions = antProject.allTopLevelAntDefinitions();
+    assertTrue(allTopLevelAntDefinitions.size > 0);
+    printAntDefinitions();
+}
+
+test void testAntDefinition() {
+    AntProject antProject = activeAntProject();
+    AntDefinition? copyAntDefinition = filterAntDefinition(antProject.allTopLevelAntDefinitions(), "copy");
+    assert(exists copyAntDefinition);
+    {String*} copyAttributeNames = copyAntDefinition.attributes().map<String>((AntAttributeDefinition a) => a.name);
+    assertTrue(copyAttributeNames.contains("todir"));
+    AntDefinition? filesetAntDefinition = filterAntDefinition(copyAntDefinition.nestedAntDefinitions(), "fileset");
+    assert(exists filesetAntDefinition);
+    {String*} filesetAttributeNames = filesetAntDefinition.attributes().map<String>((AntAttributeDefinition a) => a.name);
+    assertTrue(filesetAttributeNames.contains("dir"));
+    AntDefinition? includeAntDefinition = filterAntDefinition(filesetAntDefinition.nestedAntDefinitions(), "include");
+    assert(exists includeAntDefinition);
+    {String*} includeAttributeNames = includeAntDefinition.attributes().map<String>((AntAttributeDefinition a) => a.name);
+    assertTrue(includeAttributeNames.contains("name"));
+}
+
+test void testProperties() {
+    AntProject antProject = activeAntProject();
+    Map<String,String> allProperties = antProject.allProperties();
+    assertTrue(allProperties.size > 0);
+    // now print out all properties
+    Collection<String> propertyNames = allProperties.keys;
+    String[] propertyNamesSorted = propertyNames.sort(byIncreasing((String s) => s));
+    for(propertyName in propertyNamesSorted) {
+        String? propertyValue = allProperties.get(propertyName);
+        if(exists propertyValue) {
+            print("``propertyName``=``propertyValue``");
+        }
+    }
+}
+
+test void testProperty() {
+    String propertyName = "test.ceylon.build.tasks.ant.test-property";
+    String propertyConstant = "test-property-set";
+    AntProject antProject = activeAntProject();
+    antProject.setProperty(propertyName, null);
+    String? propertyValue1 = antProject.getProperty(propertyName);
+    assertEquals(propertyValue1, null);
+    antProject.setProperty(propertyName, propertyConstant);
+    String? propertyValue2 = antProject.getProperty(propertyName);
+    assertEquals(propertyValue2, propertyConstant);
+}
+
+"""
+   Checks the difference between top level <include> task and <include> datatype within <fileset>
+"""
+test void testIncludeAsTaskAndType() {
+    AntProject antProject = activeAntProject();
+    AntDefinition? includeAntDefinition = filterAntDefinition(antProject.allTopLevelAntDefinitions(), "include");
+    assert(exists includeAntDefinition);
+    print("<include: ``includeAntDefinition.attributes().map<String>((AntAttributeDefinition a) => a.name)``>");
+    AntDefinition? copyAntDefinition = filterAntDefinition(antProject.allTopLevelAntDefinitions(), "copy");
+    assert(exists copyAntDefinition);
+    print("<copy: ``copyAntDefinition.attributes().map<String>((AntAttributeDefinition a) => a.name)``>");
+    AntDefinition? copyFilesetAntDefinition = filterAntDefinition(copyAntDefinition.nestedAntDefinitions(), "fileset");
+    assert(exists copyFilesetAntDefinition);
+    print("<copy-fileset: ``copyFilesetAntDefinition.attributes().map<String>((AntAttributeDefinition a) => a.name)``>");
+    AntDefinition? copyFilesetIncludeAntDefinition = filterAntDefinition(copyFilesetAntDefinition.nestedAntDefinitions(), "include");
+    assert(exists copyFilesetIncludeAntDefinition);
+    print("<copy-fileset-include: ``copyFilesetIncludeAntDefinition.attributes().map<String>((AntAttributeDefinition a) => a.name)``>");
+    assertTrue(includeAntDefinition.isTask());
+    assertTrue(includeAntDefinition.attributes().map<String>((AntAttributeDefinition a) => a.name).contains("taskname"));
+    assertFalse(includeAntDefinition.attributes().map<String>((AntAttributeDefinition a) => a.name).contains("name"));
+    assertFalse(copyFilesetIncludeAntDefinition.isTask());
+    assertTrue(copyFilesetIncludeAntDefinition.attributes().map<String>((AntAttributeDefinition a) => a.name).contains("name"));
+    assertFalse(copyFilesetIncludeAntDefinition.attributes().map<String>((AntAttributeDefinition a) => a.name).contains("taskname"));
+}
+
+"""
+   Test whether a task with wrapped implementation can be executed.
+"""
+test void testImplementationWrapped() {
+    AntProject antProject = activeAntProject();
+    AntDefinition? waitforAntDefinition = filterAntDefinition(antProject.allTopLevelAntDefinitions(), "waitfor");
+    assert(exists waitforAntDefinition);
+    assertTrue(waitforAntDefinition.implementationWrapped, "Task waitfor should be implementationWrapped in Ant 1.9.4");
+    antProject.setProperty("testImplementationWrapped", null);
+    ant("waitfor", { "maxwait" -> "100", "checkevery" -> "10", "timeoutproperty" -> "testImplementationWrapped" } , [
+        Ant("equals", { "arg1" -> "A", "arg2" -> "B" })
+    ] );
+    String? timeoutproperty = antProject.getProperty("testImplementationWrapped");
+    "Check timeoutproperty"
+    assert(exists timeoutproperty);
+    assertTrue(timeoutproperty == "true");
+}
+
+"""
+   Test whether the use of antlib of an external module works.
+"""
+test void testExternalTask() {
+    AntProject antProject = activeAntProject();
+    List<AntDefinition> allTopLevelAntDefinitions1 = antProject.allTopLevelAntDefinitions();
+    antProject.addModule("ant-contrib.ant-contrib", "1.0b3");
+    ant("taskdef", { "resource" -> "net/sf/antcontrib/antlib.xml", "onerror" -> "fail" } );
+    List<AntDefinition> allTopLevelAntDefinitions2 = antProject.allTopLevelAntDefinitions();
+    printAdditionalAntDefinitions(allTopLevelAntDefinitions1, allTopLevelAntDefinitions2);
+    assertTrue(allTopLevelAntDefinitions1.size < allTopLevelAntDefinitions2.size);
+    antProject.setProperty("testExternalTask", "one");
+    ant("var", { "name" -> "testExternalTask", "value" -> "two" } );
+    String? var = antProject.getProperty("testExternalTask");
+    assert(exists var);
+    assertTrue(var == "two");
+}

--- a/test-source/test/ceylon/build/tasks/ant/utils.ceylon
+++ b/test-source/test/ceylon/build/tasks/ant/utils.ceylon
@@ -1,0 +1,58 @@
+import ceylon.file { Nil, Path, Directory, parsePath, File }
+import ceylon.build.tasks.ant { activeAntProject, AntProject, AntDefinition }
+import ceylon.language.meta.model { Interface }
+import ceylon.test { test, assertTrue }
+
+File|Directory|Nil retrieveActualResource(String relativeResourceName) {
+    AntProject antProject = activeAntProject();
+    String effectiveBaseDirectory = antProject.effectiveBaseDirectory();
+    Path exampleFilePath = parsePath(effectiveBaseDirectory + "/" + relativeResourceName);
+    File|Directory|Nil actualResource = exampleFilePath.resource.linkedResource;
+    return actualResource;
+}
+
+void verifyResource(String relativeResourceName, Interface<File|Directory|Nil> expectedResourceType, String failMessage) {
+    File|Directory|Nil actualResource = retrieveActualResource(relativeResourceName);
+    if(expectedResourceType.typeOf(actualResource)) {
+        print("``relativeResourceName`` is ``expectedResourceType``");
+    } else {
+        throw Exception("``failMessage``: ``relativeResourceName`` is not ``expectedResourceType``");
+    }
+}
+
+AntDefinition? filterAntDefinition({AntDefinition*} antDefinitions, String antName) {
+    {AntDefinition*} filteredAntDefinitions = antDefinitions.filter { function selecting(AntDefinition antDefintion) => (antDefintion.antName == antName); };
+    switch (filteredAntDefinitions.size)
+    case (0) {
+        return null;
+    }
+    case (1) {
+        return filteredAntDefinitions.first;
+    }
+    else {
+        throw Exception("More than one Ant type/task found for ``antName``");
+    }
+}
+
+void printAntDefinitions({AntDefinition*}? antDefinitions = null) {
+    {AntDefinition*} printedAntDefinitions;
+    if (exists antDefinitions) {
+        printedAntDefinitions = antDefinitions;
+    } else {
+        AntProject antProject = activeAntProject();
+        printedAntDefinitions = antProject.allTopLevelAntDefinitions();
+    }
+    for(antDefinition in printedAntDefinitions) {
+        value antName = antDefinition.antName.padTrailing(22);
+        value wrapped = antDefinition.implementationWrapped then "#" else " ";
+        value className = antDefinition.effectiveElementTypeClassName;
+        print("``antName`` ``wrapped`` ``className``");
+    }
+}
+
+void printAdditionalAntDefinitions({AntDefinition*} antDefinitions1, {AntDefinition*} antDefinitions2) {
+    {AntDefinition*} filteredAntDefinitions = antDefinitions2.filter(
+        (AntDefinition element) => !antDefinitions1.contains(element)
+    );
+    printAntDefinitions(filteredAntDefinitions);
+}


### PR DESCRIPTION
This pull request contains the new module `ceylon.build.tasks.ant` with test module.

It doesn't touch anything of the existing project, except that it adds the Maven Aether repository.

Compiled with Ceylon 1.1 from 2014-07-10, which doesn't reflect FroMage's latest binary changes to the module descriptor. But this change affects `ceylon.build.runner` and not `ceylon.build.tasks.ant`.
#### From the module documentation:
# Apache Ant wrapper

Enables you to write Apache Ant scripts in Ceylon. [Apache Ant](https://ant.apache.org/) is a build/batch tool widely used by Java programmers, with which XML is commonly used as definition language.

It facilitates the use of Ant-types, Ant-tasks, and Ant-processes, including introspection, being used within Ceylon. It is not intended to imitate Ant's `target` mechanism.
## Usage

Basically it's a mapping from Ant's XML description language to Ceylon. Elements and attributes are `String`s as Ant itself has a dynamic nature.

Also it is important to distinguish between Ant types and Ant tasks. Types are data holders like `<fileset>` and task are executables like `<copy>`.

Consider the following Ant snippet:

``` xml
<property name="buildDirectory" value="target/build"/>
<copy todir="${buildDirectory}/sub-directory">
    <fileset dir="${buildDirectory}">
        <include name="example.txt"/>
    </fileset>
</copy>
```

The above Ant snippet becomes with the value `buildDirectory` the following Ceylon code:

``` ceylon
value buildDirectory = "target/build";
ant("copy", { "todir" -> "``buildDirectory``/sub-directory" }, [
    Ant("fileset", { "dir" -> "``buildDirectory``" }, [
        Ant("include", { "name" -> "example.txt" } )
    ] )
] );
```

So types like `<fileset>` are built using the `Ant` class. For executing a tasks, use the `ant()` functions, which actually builds an `Ant` object and then calls `execute()` on it.
## External modules

Ant allows users to add their own types and tasks by adding them to Java's classpath. As the module system doesn't allow using classes from modules not imported directly, you need to use `AntProject::addModule()` to add a module to the class loader of `ceylon.build.tasks.ant`, so Ant can use the classes. Before actually using these types and tasks you have to initialize Ant with `<typedef>` or `<taskdef>`.

Example:

``` ceylon
AntProject antProject = activeAntProject();
antProject.addModule("org.apache.ant.ant-commons-net", "1.9.4");
ant("taskdef", { "name" -> "ftp", "classname" -> "org.apache.tools.ant.taskdefs.optional.net.FTP" } );
```
## Introspection

Ant introspection works from top down, as the implementing classes of Ant types change depending on their location in the XML hierarchy.

Example:

``` ceylon
AntProject antProject = currentAntProject();
AntDefinition? copyAntDefinition = antProject.allTopLevelAntDefinitions().filter { (AntDefinition a) => (a.antName == "copy"); }.first;
assert(exists copyAntDefinition);
AntDefinition? filesetAntDefinition = copyAntDefinition.nestedAntDefinitions().filter { (AntDefinition a) => (a.antName == "fileset"); }.first;
assert(exists filesetAntDefinition);
AntDefinition? includeAntDefinition = includeAntDefinition.nestedAntDefinitions().filter { (AntDefinition a) => (a.antName == "include"); }.first;
assert(exists includeAntDefinition);
```
## Caveats

XML/Ant namespaces are not supported.
